### PR TITLE
Add basic thorttler/exponential backoff policy for retry/Defination of throttling exception

### DIFF
--- a/server/src/main/java/org/opensearch/OpenSearchException.java
+++ b/server/src/main/java/org/opensearch/OpenSearchException.java
@@ -1594,6 +1594,15 @@ public class OpenSearchException extends RuntimeException implements ToXContentF
             org.opensearch.transport.NoSeedNodeLeftException::new,
             160,
             LegacyESVersion.V_7_10_0
+        ),
+        /**
+         * TODO: Change the version number of check as per version in which this change will be merged.
+         */
+        MASTER_TASK_THROTTLED_EXCEPTION(
+            org.opensearch.cluster.service.MasterTaskThrottlingException.class,
+            org.opensearch.cluster.service.MasterTaskThrottlingException::new,
+            161,
+            Version.V_1_3_0
         );
 
         final Class<? extends OpenSearchException> exceptionClass;

--- a/server/src/main/java/org/opensearch/cluster/service/MasterTaskThrottlingException.java
+++ b/server/src/main/java/org/opensearch/cluster/service/MasterTaskThrottlingException.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * Exception raised from master node due to task throttling.
+ */
+public class MasterTaskThrottlingException extends OpenSearchException {
+
+    public MasterTaskThrottlingException(String msg, Object... args) {
+        super(msg, args);
+    }
+
+    public MasterTaskThrottlingException(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/service/Throttler.java
+++ b/server/src/main/java/org/opensearch/cluster/service/Throttler.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.opensearch.common.AdjustableSemaphore;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Base class for Throttling logic.
+ * It provides throttling functionality over multiple keys.
+ * It provides the functionality of enable/disable throttling using enableThrottling variable.
+ *
+ * @param <T> the type of key on which we want to do throttling.
+ */
+public class Throttler<T> {
+    protected ConcurrentMap<T, AdjustableSemaphore> semaphores = new ConcurrentHashMap<T, AdjustableSemaphore>();
+
+    private boolean throttlingEnabled;
+
+    public Throttler(final boolean throttlingEnabled) {
+        this.throttlingEnabled = throttlingEnabled;
+    }
+
+    /**
+     * Method to acquire permits for a key type.
+     * If throttling is disabled, it will always return True,
+     * else it will return true if permits can be acquired within threshold limits.
+     *
+     * If threshold is not set for key then also it will return True.
+     *
+     * @param type Key for which we want to acquire permits.
+     * @param permits Number of permits to acquire.
+     * @return boolean representing was it able to acquire the permits or not.
+     */
+    public boolean acquire(final T type, final int permits) {
+        assert permits > 0;
+        AdjustableSemaphore semaphore = semaphores.get(type);
+        if (throttlingEnabled && Objects.nonNull(semaphore)) {
+            return semaphore.tryAcquire(permits);
+        }
+        return true;
+    }
+
+    /**
+     * Release the given permits for given type.
+     *
+     * @param type key for which we want to release permits.
+     * @param permits number of permits to release.
+     */
+    public void release(final T type, final int permits) {
+        assert permits > 0;
+        AdjustableSemaphore semaphore = semaphores.get(type);
+        if (throttlingEnabled && Objects.nonNull(semaphore)) {
+            semaphore.release(permits);
+            assert semaphore.availablePermits() <= semaphore.getMaxPermits();
+        }
+    }
+
+    /**
+     * Update the Threshold for throttling for given type.
+     *
+     * @param key Key for which we want to update limit.
+     * @param newLimit Updated limit.
+     */
+    public synchronized void updateThrottlingLimit(final T key, final Integer newLimit) {
+        assert newLimit >= 0;
+        if (semaphores.containsKey(key)) {
+            semaphores.get(key).setMaxPermits(newLimit);
+        } else {
+            semaphores.put(key, new AdjustableSemaphore(newLimit));
+        }
+    }
+
+    /**
+     * Remove the threshold for given key.
+     * Throttler will no longer do throttling for given key.
+     *
+     * @param key Key for which we want to remove throttling.
+     */
+    public synchronized void removeThrottlingLimit(final T key) {
+        assert semaphores.containsKey(key);
+        semaphores.remove(key);
+    }
+
+    /**
+     * Set flag for enabling/disabling the throttling logic.
+     * Clear the state of previous semaphores with each update.
+     *
+     * @param throttlingEnabled flag repressing enabled/disabled throttling.
+     */
+    public synchronized void setThrottlingEnabled(final boolean throttlingEnabled) {
+        this.throttlingEnabled = throttlingEnabled;
+        for (T key : semaphores.keySet()) {
+            semaphores.put(key, new AdjustableSemaphore(semaphores.get(key).getMaxPermits()));
+        }
+    }
+
+    public Integer getThrottlingLimit(final T key) {
+        if (semaphores.containsKey(key)) {
+            return semaphores.get(key).getMaxPermits();
+        }
+        return null;
+    }
+
+    public boolean isThrottlingEnabled() {
+        return throttlingEnabled;
+    }
+}

--- a/server/src/main/java/org/opensearch/common/AdjustableSemaphore.java
+++ b/server/src/main/java/org/opensearch/common/AdjustableSemaphore.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * AdjustableSemaphore is Extended Semphore where we can change maxPermits.
+ */
+public class AdjustableSemaphore extends Semaphore {
+    private final Object maxPermitsMutex = new Object();
+    private int maxPermits;
+
+    public AdjustableSemaphore(int maxPermits) {
+        super(maxPermits);
+        this.maxPermits = maxPermits;
+    }
+
+    /**
+     * Update the maxPermits in semaphore
+     */
+    public void setMaxPermits(int permits) {
+        synchronized (maxPermitsMutex) {
+            final int diff = Math.subtractExact(permits, maxPermits);
+            if (diff > 0) {
+                // add permits
+                release(diff);
+            } else if (diff < 0) {
+                // remove permits
+                reducePermits(Math.negateExact(diff));
+            }
+            maxPermits = permits;
+        }
+    }
+
+    /**
+     * Returns maxPermits.
+     */
+    public int getMaxPermits() {
+        return maxPermits;
+    }
+}

--- a/server/src/test/java/org/opensearch/action/bulk/BackoffPolicyTests.java
+++ b/server/src/test/java/org/opensearch/action/bulk/BackoffPolicyTests.java
@@ -75,4 +75,27 @@ public class BackoffPolicyTests extends OpenSearchTestCase {
             assertEquals(expectedRetries, retries.get());
         }
     }
+
+    public void testEqualJitterExponentialBackOffPolicy() {
+        int baseDelay = 10;
+        int maxDelay = 10000;
+        BackoffPolicy policy = BackoffPolicy.exponentialEqualJitterBackoff(baseDelay, maxDelay);
+        Iterator<TimeValue> iterator = policy.iterator();
+
+        // Assert equal jitter
+        int retriesTillMaxDelay = 10;
+        for (int i = 0; i < retriesTillMaxDelay; i++) {
+            TimeValue delay = iterator.next();
+            assertTrue(delay.getMillis() >= baseDelay * (1L << i) / 2);
+            assertTrue(delay.getMillis() <= baseDelay * (1L << i));
+        }
+
+        // Now policy should return max delay for next retries.
+        int retriesAfterMaxDelay = randomInt(10);
+        for (int i = 0; i < retriesAfterMaxDelay; i++) {
+            TimeValue delay = iterator.next();
+            assertTrue(delay.getMillis() >= maxDelay / 2);
+            assertTrue(delay.getMillis() <= maxDelay);
+        }
+    }
 }

--- a/server/src/test/java/org/opensearch/cluster/service/ThrottlerTests.java
+++ b/server/src/test/java/org/opensearch/cluster/service/ThrottlerTests.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.service;
+
+import org.opensearch.common.AdjustableSemaphore;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Contains tests of {@link Throttler}
+ */
+public class ThrottlerTests extends OpenSearchTestCase {
+
+    public void testDisabledThrottling() {
+        Throttler throttler = new Throttler(true);
+        throttler.updateThrottlingLimit("testKey", 1);
+        throttler.setThrottlingEnabled(false);
+        boolean firstCall = throttler.acquire("testKey", 5);
+        assertTrue(firstCall);
+    }
+
+    public void testThrottling() {
+        Throttler throttler = new Throttler(true);
+        throttler.updateThrottlingLimit("testKey", 5);
+        boolean firstCall = throttler.acquire("testKey", 1);
+        assertTrue(firstCall);
+
+        boolean secondCall = throttler.acquire("testKey", 2);
+        assertTrue(secondCall);
+
+        boolean thirdCall = throttler.acquire("testKey", 4);
+        assertFalse(thirdCall);
+
+        // will remove used value
+        throttler.release("testKey", 2);
+        boolean fourthCall = throttler.acquire("testKey", 4);
+        assertTrue(fourthCall);
+
+        boolean fifthCall = throttler.acquire("testKey", 1);
+        assertFalse(fifthCall);
+
+        // update limit and check
+        throttler.updateThrottlingLimit("testKey", 6);
+        boolean sixthCall = throttler.acquire("testKey", 1);
+        assertTrue(sixthCall);
+    }
+
+    public void testAcquireWithFlippingOfThrottlingFlag() throws Exception {
+        String test_task = "test";
+        Throttler<String> throttler = new Throttler(true);
+        throttler.updateThrottlingLimit(test_task, 1);
+        assertTrue(throttler.acquire(test_task, 1));
+        assertFalse(throttler.acquire(test_task, 1));
+
+        throttler.setThrottlingEnabled(false);
+        throttler.setThrottlingEnabled(true);
+        assertEquals(1, throttler.getThrottlingLimit(test_task).intValue());
+        assertTrue(throttler.acquire(test_task, 1));
+        assertFalse(throttler.acquire(test_task, 1));
+
+    }
+
+    public void testThrottlingWithoutLimit() {
+        Throttler throttler = new Throttler(true);
+        boolean firstCall = throttler.acquire("testKey", 1);
+        assertTrue(firstCall);
+
+        boolean secondCall = throttler.acquire("testKey", 2000);
+        assertTrue(secondCall);
+    }
+
+    public void testRemoveThrottlingLimit() {
+        Throttler throttler = new Throttler(true);
+        throttler.updateThrottlingLimit("testKey", 5);
+
+        boolean firstCall = throttler.acquire("testKey", 1);
+        assertTrue(firstCall);
+
+        boolean secondCall = throttler.acquire("testKey", 5);
+        assertFalse(secondCall);
+
+        throttler.removeThrottlingLimit("testKey");
+        boolean thirdCall = throttler.acquire("testKey", 500);
+        assertTrue(thirdCall);
+    }
+
+    public void testUpdateLimitForThrottlingSemaphore() {
+        int initialLimit = randomInt(10);
+        AdjustableSemaphore semaphore = new AdjustableSemaphore(initialLimit);
+        assertEquals(initialLimit, semaphore.availablePermits());
+
+        int newIncreasedLimit = randomIntBetween(initialLimit, 20);
+        semaphore.setMaxPermits(newIncreasedLimit);
+        assertEquals(newIncreasedLimit, semaphore.availablePermits());
+
+        int newDecreasedLimit = randomInt(newIncreasedLimit - 1);
+        semaphore.setMaxPermits(newDecreasedLimit);
+        assertEquals(newDecreasedLimit, semaphore.availablePermits());
+    }
+}


### PR DESCRIPTION
Add basic thorttler/exponential backoff policy for retry/Defination of throttling exception

Signed-off-by: Dhwanil Patel <dhwanip@amazon.com>

### Description
This is one of multiple PR planned for master task throttling. In this PR we are introducing couple of new classes required for upcoming PRs. We have also introduced new Throttling Exception which will be thrown from master node whenever it throttles any tasks.

New class/Method introduced:
**Throttler** : Base class for Throttling logic. It provides throttling functionality over multiple keys.
**ExponentialBackOffPolicy** : It provides exponential backoff between retries until it reaches maxDelay. It uses equal jitter scheme as it is being used for throttled exceptions. It will make random distribution and also guarantees a minimum delay.
**AdjustableSemaphore**: AdjustableSemaphore is Extended Semphore where we can change maxPermits.
 
### Issues Resolved
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
